### PR TITLE
Fix hook module loading.

### DIFF
--- a/on-add-pirate
+++ b/on-add-pirate
@@ -20,7 +20,7 @@ def find_hooks(file_prefix):
         # Load the module
         module_dir = os.path.dirname(module_path)
         module_filename = os.path.basename(module_path)
-        module_name = 'pirate_{0}_{1}'.format(module_dir, module_filename)
+        module_name = module_filename.rstrip(".py")
         module = imp.load_source(module_name, module_path)
 
         # Find all hook methods available

--- a/on-modify-pirate
+++ b/on-modify-pirate
@@ -20,7 +20,7 @@ def find_hooks(file_prefix):
         # Load the module
         module_dir = os.path.dirname(module_path)
         module_filename = os.path.basename(module_path)
-        module_name = 'pirate_{0}_{1}'.format(module_dir, module_filename)
+        module_name = module_filename.rstrip(".py")
         module = imp.load_source(module_name, module_path)
 
         # Find all hook methods available


### PR DESCRIPTION
I installed taskpirate along with the shift-recurrence hook as instructed in taskpirate's README.md, but upon creating a new task, the following errors happen:

    [dkasak@telperion ~]% task add test
    /home/dkasak/.local/share/tasks/hooks/shift-recurrence/pirate_add_shift_recurrence.py:3: RuntimeWarning: Parent module 'pirate_add_shift_recurrence' not found while handling absolute import
    import sys
    /home/dkasak/.local/share/tasks/hooks/shift-recurrence/pirate_add_shift_recurrence.py:4: RuntimeWarning: Parent module 'pirate_add_shift_recurrence' not found while handling absolute import
    import os
    /home/dkasak/.local/share/tasks/hooks/shift-recurrence/pirate_add_shift_recurrence.py:5: RuntimeWarning: Parent module 'pirate_add_shift_recurrence' not found while handling absolute import
    from tasklib.task import TaskWarrior
    Created task 19.

This PR fixes module name calculation so this works as expected. Also, I just noticed the installation instructions in shift-recurrence's README.md are outdated since it now uses taskpirate.