### PR TITLE
Fix python reference and imports

### DIFF
--- a/on-add-pirate
+++ b/on-add-pirate
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 import glob
 import imp

--- a/on-add-pirate
+++ b/on-add-pirate
@@ -4,7 +4,7 @@ import glob
 import imp
 import os
 
-from tasklib.task import TaskWarrior, Task
+from tasklib import TaskWarrior, Task
 
 
 def find_hooks(file_prefix):

--- a/on-modify-pirate
+++ b/on-modify-pirate
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 import glob
 import imp

--- a/on-modify-pirate
+++ b/on-modify-pirate
@@ -4,7 +4,7 @@ import glob
 import imp
 import os
 
-from tasklib.task import TaskWarrior, Task
+from tasklib import TaskWarrior, Task
 
 
 def find_hooks(file_prefix):


### PR DESCRIPTION
I wanted to use task.shift-recurrence but ran into these issues on MacOS. 

- Use env to select the right python executable. Fixes issue on MacOS
with selecting the system python instead of the Homebrew python.
- Existing imports did not work using the development version of tasklib
mentioned in the README.