### PR TITLE
Update shebangs to python3

### DIFF
--- a/on-add-pirate
+++ b/on-add-pirate
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import glob
 from types import ModuleType

--- a/on-modify-pirate
+++ b/on-modify-pirate
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import glob
 from types import ModuleType


### PR DESCRIPTION
Python 2 is EOL and some distros (e.g. Debian) no longer provide the
"python" binary, only "python3" and possibly "python2".

Fixes: #10